### PR TITLE
(SIMP-5754) Fix `pup_4` Gitlab CI cache poisoning

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,16 +1,14 @@
 # The testing matrix considers ruby/puppet versions supported by SIMP and PE:
 #
-# https://puppet.com/docs/pe/2018.1/component_versions_in_recent_pe_releases.html
+# https://puppet.com/docs/pe/2019.0/component_versions_in_recent_pe_releases.html
 # https://puppet.com/misc/puppet-enterprise-lifecycle
 # https://puppet.com/docs/pe/2018.1/overview/getting_support_for_pe.html
 # ------------------------------------------------------------------------------
 # Release       Puppet   Ruby   EOL
 # SIMP 6.1      4.10.6   2.1.9  TBD
 # SIMP 6.2      4.10.12  2.1.9  TBD
-# PE 2016.4.15  4.10.12  2.1.9  2018-12 (LTS)
-# PE 2017.3.10  5.3.8    2.4.4  2018-12 (STS)
 # SIMP 6.3      5.5.7    2.4.4  TBD***
-# PE 2018.1     5.5.6    2.4.4  2020-05 (LTS)***
+# PE 2018.1     5.5.8    2.4.4  2020-05 (LTS)***
 # PE 2019.0     6.0      2.5.1  2019-08-31^^^
 #
 # *** = Modules created for SIMP 6.3+ are not required to support Puppet < 5.5
@@ -22,8 +20,6 @@ stages:
   - 'acceptance'
   - 'compliance'
   - 'deployment'
-
-image: 'ruby:2.4'
 
 variables:
   PUPPET_VERSION:    'UNDEFINED' # <- Matrixed jobs MUST override this (or fail)

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,14 +5,16 @@
 # https://puppet.com/docs/pe/2018.1/overview/getting_support_for_pe.html
 # ------------------------------------------------------------------------------
 # Release       Puppet   Ruby   EOL
-# PE 2016.4.15  4.10.12  2.1.9  2018-12 (LTS)
-# SIMP 6.0      4.8.2    2.1.9  TBD
 # SIMP 6.1      4.10.6   2.1.9  TBD
 # SIMP 6.2      4.10.12  2.1.9  TBD
+# PE 2016.4.15  4.10.12  2.1.9  2018-12 (LTS)
+# PE 2017.3.10  5.3.8    2.4.4  2018-12 (STS)
 # SIMP 6.3      5.5.7    2.4.4  TBD***
 # PE 2018.1     5.5.6    2.4.4  2020-05 (LTS)***
+# PE 2019.0     6.0      2.5.1  2019-08-31^^^
 #
 # *** = Modules created for SIMP 6.3+ are not required to support Puppet < 5.5
+# ^^^ = SIMP doesn't support 6 yet; tests are info-only and allowed to fail
 ---
 stages:
   - 'sanity'
@@ -25,7 +27,7 @@ image: 'ruby:2.4'
 
 variables:
   PUPPET_VERSION:    'UNDEFINED' # <- Matrixed jobs MUST override this (or fail)
-  BUNDLER_VERSION:   '1.16.1'
+  BUNDLER_VERSION:   '1.17.1'
 
   # Force dependencies into a path the gitlab-runner user can write to.
   # (This avoids some failures on Runners with misconfigured ruby environments.)
@@ -48,57 +50,62 @@ variables:
     paths:
       - '.vendor'
   before_script:
-    - 'ruby -e "puts %(Environment Variables:\n  * #{ENV.keys.grep(/PUPPET|SIMP|BEAKER|MATRIX/).map{|v| %(#{v} = #{ENV[v]})}.join(%(\n  * ))})"'
-    - 'declare GEM_BUNDLER_VER=(-v "~> ${BUNDLER_VERSION:-1.16.0}")'
+    - 'ruby -e "puts %(\n\n), %q(=)*80, %(\nSIMP-relevant Environment Variables:\n\n#{e=ENV.keys.grep(/^PUPPET|^SIMP|^BEAKER|MATRIX/); pad=e.map{|x| x.size}.max+1; e.map{|v| %(    * #{%(#{v}:).ljust(pad)} #{39.chr + ENV[v] + 39.chr}\n)}.join}\n),  %q(=)*80, %(\n\n)"'
+    - 'declare GEM_BUNDLER_VER=(-v "~> ${BUNDLER_VERSION:-1.17.1}")'
     - 'declare GEM_INSTALL_CMD=(gem install --no-document)'
     - 'declare BUNDLER_INSTALL_CMD=(bundle install --no-binstubs --jobs $(nproc) "${FLAGS[@]}")'
     - 'mkdir -p ${GEM_HOME} ${BUNDLER_BIN}'
     - 'gem list -ie "${GEM_BUNDLER_VER[@]}" --silent bundler || "${GEM_INSTALL_CMD[@]}" --local "${GEM_BUNDLER_VER[@]}" bundler || "${GEM_INSTALL_CMD[@]}" "${GEM_BUNDLER_VER[@]}" bundler'
     - 'rm -rf pkg/ || :'
-    - 'bundle check || rm -f Gemfile.lock && ("${BUNDLER_INSTALL_CMD[@]}" --local || "${BUNDLER_INSTALL_CMD[@]}" || bundle pristine ||  "${BUNDLER_INSTALL_CMD[@]}") || echo "PIPELINE: Bundler could not find everything"'
+    - 'bundle check || rm -f Gemfile.lock && ("${BUNDLER_INSTALL_CMD[@]}" --local || "${BUNDLER_INSTALL_CMD[@]}" || bundle pristine ||  "${BUNDLER_INSTALL_CMD[@]}") || { echo "PIPELINE: Bundler could not install everything (see log output above)" && exit 99 ; }'
 
 # To avoid running a prohibitive number of tests every commit,
 # don't set this env var in your gitlab instance
 .only_with_SIMP_FULL_MATRIX: &only_with_SIMP_FULL_MATRIX
   only:
     variables:
-      - $SIMP_FULL_MATRIX
+      - $SIMP_FULL_MATRIX == "yes"
 
-# Puppet + testing environments
-# --------------------------------------
+# Puppet Versions
+#-----------------------------------------------------------------------
+
+.pup_4: &pup_4
+  image: 'ruby:2.1'
+  variables:
+    PUPPET_VERSION: '~> 4.0'
+    MATRIX_RUBY_VERSION: '2.1'
+
 .pup_4_10: &pup_4_10
   image: 'ruby:2.1'
   variables:
     PUPPET_VERSION: '~> 4.10.4'
     MATRIX_RUBY_VERSION: '2.1'
 
-.pup_4_latest: &pup_4_latest
-  image: 'ruby:2.1'
-  variables:
-    PUPPET_VERSION: '~> 4.0'
-    MATRIX_RUBY_VERSION: '2.1'
-
-.pup_5_3: &pup_5_3
-  image: 'ruby:2.4'
-  variables:
-    PUPPET_VERSION: '~> 5.3.2'
-    BEAKER_PUPPET_COLLECTION: 'puppet5'
-    MATRIX_RUBY_VERSION: '2.4'
-
-.pup_5_5: &pup_5_5
-  image: 'ruby:2.4'
-  variables:
-    PUPPET_VERSION: '~> 5.5.6'
-    BEAKER_PUPPET_COLLECTION: 'puppet5'
-    MATRIX_RUBY_VERSION: '2.4'
-
-.pup_5_latest: &pup_5_latest
+.pup_5: &pup_5
   image: 'ruby:2.4'
   variables:
     PUPPET_VERSION: '~> 5.0'
     BEAKER_PUPPET_COLLECTION: 'puppet5'
     MATRIX_RUBY_VERSION: '2.4'
 
+.pup_5_5_7: &pup_5_5_7
+  image: 'ruby:2.4'
+  variables:
+    PUPPET_VERSION: '5.5.7'
+    BEAKER_PUPPET_COLLECTION: 'puppet5'
+    MATRIX_RUBY_VERSION: '2.4'
+
+.pup_6: &pup_6
+  allow_failure: true
+  image: 'ruby:2.5'
+  variables:
+    PUPPET_VERSION: '~> 6.0'
+    BEAKER_PUPPET_COLLECTION: 'puppet6'
+    MATRIX_RUBY_VERSION: '2.5'
+
+
+# Testing Environments
+#-----------------------------------------------------------------------
 
 .lint_tests: &lint_tests
   stage: 'validation'
@@ -107,6 +114,7 @@ variables:
   script:
     - 'bundle exec rake syntax'
     - 'bundle exec rake lint'
+    - 'bundle exec rake metadata_lint'
 
 .unit_tests: &unit_tests
   stage: 'validation'
@@ -130,106 +138,56 @@ variables:
 #=======================================================================
 
 sanity_checks:
-  <<: *pup_5_latest
+  <<: *pup_5
   <<: *setup_bundler_env
   stage: 'sanity'
   tags: ['docker']
   script:
+    - 'if `hash apt-get`; then apt-get update; fi'
+    - 'if `hash apt-get`; then apt-get install -y rpm; fi'
     - 'bundle exec rake check:dot_underscore'
     - 'bundle exec rake check:test_file'
     - 'bundle exec rake pkg:check_version'
     - 'bundle exec rake pkg:compare_latest_tag'
+    - 'bundle exec rake pkg:create_tag_changelog'
+    - 'bundle exec puppet module build'
 
+# Linting
+#-----------------------------------------------------------------------
 
 pup4-lint:
-  <<: *pup_4_latest
+  <<: *pup_4
   <<: *lint_tests
 
 pup5-lint:
-  <<: *pup_5_latest
+  <<: *pup_5
   <<: *lint_tests
 
+pup6-lint:
+  <<: *pup_6
+  <<: *lint_tests
+
+# Unit Tests
+#-----------------------------------------------------------------------
+
+pup5-unit:
+  <<: *pup_5
+  <<: *unit_tests
+
+pup5.5.7-unit:
+  <<: *pup_5_5_7
+  <<: *unit_tests
 
 pup4.10-unit:
   <<: *pup_4_10
   <<: *unit_tests
 
-pup5.3-unit:
-  <<: *pup_5_3
+pup6-unit:
+  <<: *pup_6
   <<: *unit_tests
 
-pup5.5-unit:
-  <<: *pup_5_5
-  <<: *unit_tests
-
-pup5.latest-unit:
-  <<: *pup_5_latest
-  <<: *unit_tests
-
-
-# Component does not have acceptance tests yet
-#pup4.10-centos-default:
-#  <<: *pup_4_10
-#  <<: *acceptance_base
-#  script:
-#    - 'bundle exec rake beaker:suites'
+# Acceptance tests
+# ==============================================================================
+# This module does not have acceptance tests yet.
 #
-#pup4.10-centos-default-fips:
-#  <<: *pup_4_10
-#  <<: *acceptance_base
-#  <<: *only_with_SIMP_FULL_MATRIX
-#  script:
-#    - 'BEAKER_fips=yes bundle exec rake beaker:suites'
-#
-#pup5.5-centos-default:
-#  <<: *pup_5_5
-#  <<: *acceptance_base
-#  script:
-#    - 'bundle exec rake beaker:suites'
-#
-#pup5.5-centos-default-fips:
-#  <<: *pup_5_5
-#  <<: *acceptance_base
-#  script:
-#    - 'BEAKER_fips=yes bundle exec rake beaker:suites'
-#
-#pup5.5-oel-default:
-#  <<: *pup_5_5
-#  <<: *acceptance_base
-#  script:
-#    - 'bundle exec rake beaker:suites[default,oel]'
-#
-#pup5.5-oel-default-fips:
-#  <<: *pup_5_5
-#  <<: *acceptance_base
-#  <<: *only_with_SIMP_FULL_MATRIX
-#  script:
-#    - 'BEAKER_fips=yes bundle exec rake beaker:suites[default,oel]'
-#
-#pup5.5-centos-compliance-fips:
-#  <<: *pup_5_5
-#  <<: *compliance_base
-#  script:
-#    - 'BEAKER_fips=yes bundle exec rake beaker:suites[compliance]'
-#
-# FUTURE
-## Deployment jobs
-##=======================================================================
-#
-#module_build:
-#  only:
-#    - 'tags'
-#  stage: 'deployment'
-#  tags:
-#    - 'docker'
-#  script:
-#    - 'bundle exec rake clean'
-#    - 'rm -rf pkg/'
-#    - 'bundle exec puppet module build'
-#  artifacts:
-#    name: 'forge_release-${CI_COMMIT_TAG}'
-#    when: 'on_success'
-#    paths:
-#      - 'pkg/${MODULE_NAME}-${MODULE_VERSION}.tar.gz'
-
-# vi:tabstop=2:shiftwidth=2:expandtab
+# See: https://simp-project.atlassian.net/browse/SIMP-5632)


### PR DESCRIPTION
This patch fixes a `.gitlab-ci.yml` bug that was posioning the GitLab
Runners' RubyGems cache.  The `pup4` YAML anchor must use `image:
'ruby:2.1'` instead of `image: 'ruby:2.4'`.

Note: This commit is part of a common asset update, and adjusts other
aspects of the `.gitlab-ci.yml` file in order to bring it in line with a
standardized pipeline.  In particular, PE 2017.3 was recently
deprecated, removing Puppet 5.3 from the test matrix of most modules.

SIMP-5985 #close
SIMP-5754 #comment updated pupmod-simp-chkrootkit