### PR TITLE
(SIMP-6229) Update upper bound stdlib < 6.0.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Thu Mar 07 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 0.1.1-0
+- Update the upper bound of stdlib to < 6.0.0
+- Update a URL in the README.md
+
 * Thu Nov 01 2018 Jeanne Greulich <jeanner.greulich@onyxpoint.com> - 0.1.0-0
 - Update badges in README.md
 - Static asset updates for puppet 5

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ SIMP Puppet modules are generally intended for use on Red Hat Enterprise Linux a
 
 ## Development
 
-Please read our [Contribution Guide] (http://simp-doc.readthedocs.io/en/stable/contributors_guide/index.html)
+Please read our [Contribution Guide] (https://simp.readthedocs.io/en/stable/contributors_guide/index.html)
 
 
 ### Acceptance tests

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-chkrootkit",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "author": "SIMP Team",
   "summary": "A SIMP puppet module for managing chkrootkit",
   "license": "Apache-2.0",
@@ -17,7 +17,7 @@
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.13.1 < 5.0.0"
+      "version_requirement": ">= 4.13.1 < 6.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
- Update the upper bound of stdlib to < 6.0.0
- Update a URL in the README.md

SIMP-6229 #comment pupmod-simp-chkrootkit